### PR TITLE
Fix Received spelling

### DIFF
--- a/MacPerformanceC.nc
+++ b/MacPerformanceC.nc
@@ -352,7 +352,7 @@ implementation
             MacPerformanceMsg* mppkt = (MacPerformanceMsg*)payload;
             if(0 == TOS_NODE_ID)
             {
-                dbg("PacketState", "Recieved: %hu ; %llu\n", mppkt->counter, sim_time());
+                dbg("PacketState", "Received: %hu ; %llu\n", mppkt->counter, sim_time());
             }
         }   
 

--- a/SimRunner.pl
+++ b/SimRunner.pl
@@ -292,7 +292,7 @@ sub getPacketData($;)
 		{
 			$packet_H_ref->{sent}->{$1} = $2;
 		}	
-		elsif($line =~ /\A.*:\sRecieved:\s(\d+)\s;\s(\d+)\Z/)
+		elsif($line =~ /\A.*:\sReceived:\s(\d+)\s;\s(\d+)\Z/)
 		{
 				$packet_H_ref->{recieved}->{$1} = $2;
 		}


### PR DESCRIPTION
## Summary
- fix spelling of `Received` in MacPerformanceC
- update regex in SimRunner

## Testing
- `perl -c SimRunner.pl`
- `perl -c MACrunner.pl`
- `python Simulation.py --help` *(fails: SyntaxError due to missing parentheses)*

------
https://chatgpt.com/codex/tasks/task_e_6842e658e7b88329961133784aa4acb1