### PR TITLE
Fix deletion of ghost packet entries

### DIFF
--- a/SimRunner.pl
+++ b/SimRunner.pl
@@ -302,10 +302,10 @@ sub getPacketData($;)
 	{
 		delete $packet_H_ref->{recieved}->{'0'};
 	}
-	if(defined($packet_H_ref->{sent}->{'0'}))
-	{
-		delete $packet_H_ref->{recieved}->{'0'};
-	}
+       if(defined($packet_H_ref->{sent}->{'0'}))
+       {
+               delete $packet_H_ref->{sent}->{'0'};
+       }
 	return $packet_H_ref;
 }
 


### PR DESCRIPTION
## Summary
- correct hash used when removing ghost packets in `getPacketData`

## Testing
- ran a small Perl script calling `getPacketData` on sample data

------
https://chatgpt.com/codex/tasks/task_e_6842e65aa6ac8329890c8e1988b7f7e7