### PR TITLE
Add test for getPacketData ghost packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# MacPerformance
+
+This repository contains scripts and simulation files for evaluating MAC performance.
+
+## Running tests
+
+Perl tests are located in the `t/` directory and can be executed with `prove`:
+
+```sh
+prove -lv t/get_packet_data.t
+```
+
+This checks that `getPacketData` correctly filters ghost node data from packet logs.

--- a/SimRunner.pl
+++ b/SimRunner.pl
@@ -302,10 +302,10 @@ sub getPacketData($;)
 	{
 		delete $packet_H_ref->{recieved}->{'0'};
 	}
-	if(defined($packet_H_ref->{sent}->{'0'}))
-	{
-		delete $packet_H_ref->{recieved}->{'0'};
-	}
+        if(defined($packet_H_ref->{sent}->{'0'}))
+        {
+                delete $packet_H_ref->{sent}->{'0'};
+        }
 	return $packet_H_ref;
 }
 

--- a/t/get_packet_data.t
+++ b/t/get_packet_data.t
@@ -1,0 +1,35 @@
+use strict;
+use warnings;
+use Test::More;
+use File::Temp qw(tempfile);
+
+# extract getPacketData sub from SimRunner.pl without executing script
+my $code;
+{
+    local $/;
+    open my $fh, '<', 'SimRunner.pl' or die $!;
+    $code = <$fh>;
+    close $fh;
+}
+my ($sub_code) = $code =~ /(sub getPacketData.*?^\})/ms;
+ok($sub_code, 'found getPacketData function');
+$sub_code =~ s/sub getPacketData\([^\)]*\)/sub getPacketData/;  # strip prototype for newer perls
+{
+    no warnings 'redefine';
+    eval $sub_code;
+    die $@ if $@;
+}
+
+my ($fh, $file) = tempfile();
+print $fh "0: PacketState: Sent: 0 ; 100\n";
+print $fh "0: PacketState: Recieved: 0 ; 120\n";
+print $fh "1: PacketState: Sent: 1 ; 150\n";
+print $fh "1: PacketState: Recieved: 1 ; 180\n";
+close $fh;
+
+my $res = getPacketData($file);
+
+ok(!exists $res->{sent}{'0'}, 'ghost node not in sent');
+ok(!exists $res->{recieved}{'0'}, 'ghost node not in recieved');
+
+done_testing();


### PR DESCRIPTION
## Summary
- add `t/get_packet_data.t` with a simple packet log check
- fix `getPacketData` so ghost packets are removed from both `sent` and `recieved`
- document running tests in new `README.md`

## Testing
- `prove -lv t/get_packet_data.t`

------
https://chatgpt.com/codex/tasks/task_e_6842e65d30508329b4cb6adeaa55429e